### PR TITLE
exports Table interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare module 'pdfkit-table'
 		[key: string]: string | { label: string; options?: DataOptions };
 	}
 
-	interface Table {
+	export interface Table {
 		title?: string;
 		subtitle?: string;
 		headers?: (string | Header)[];


### PR DESCRIPTION
Exports the Table interface so that developers can import it into their modules to ensure they are building their table objects properly.